### PR TITLE
Image link workaround

### DIFF
--- a/iip_smr_web_app/templates/iip_search_templates/viewinscr.html
+++ b/iip_smr_web_app/templates/iip_search_templates/viewinscr.html
@@ -42,7 +42,7 @@ ol li {
 {%block viewinscr%}
 <script type="text/javascript">
 function ImgError(source){
-    source.src = "../../static/resources/img/noimg.png";
+    source.src = "https://github.com/Brown-University-Library/iip_smr_web_project/raw/zak/iip_smr_web_app/static/resources/img/noimg.png";
     source.onerror = "";
     source.width = "150";
     return true;


### PR DESCRIPTION
Image link for the 404 image goes to the github URL now:
https://github.com/Brown-University-Library/iip_smr_web_project/raw/zak/iip_smr_web_app/static/resources/img/noimg.png